### PR TITLE
Make using alloc optional and usable on stable Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["logging", "hex", "dump", "binary"]
 [dependencies]
 
 [dev-dependencies]
+heapless = "0.5.5"
 
 [features]
 default = ["alloc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ keywords = ["logging", "hex", "dump", "binary"]
 [dev-dependencies]
 
 [features]
-default = []
+default = ["alloc"]
 alloc = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![cfg_attr(feature = "alloc", feature(alloc))]
 
 //! A Rust library providing pretty hex dump.
 //!
@@ -57,6 +56,7 @@
 //! 0018:   db b1 bc 35 bf ee         ...5..
 //! ```
 
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 mod pretty_hex;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@
 //! use pretty_hex::*;
 //!
 //! let v = vec![222, 173, 190, 239, 202, 254, 32, 24];
+//! # #[cfg(feature = "alloc")]
 //! assert_eq!(simple_hex(&v), format!("{}", v.hex_dump()));
 //!
 //! println!("{}", v.hex_dump());
@@ -25,6 +26,7 @@
 //! use pretty_hex::*;
 //!
 //! let v = &include_bytes!("../tests/data");
+//! # #[cfg(feature = "alloc")]
 //! assert_eq!(pretty_hex(&v), format!("{:?}", v.hex_dump()));
 //!
 //! println!("{:?}", v.hex_dump());
@@ -43,6 +45,7 @@
 //! let cfg = HexConfig {title: false, width: 8, group: 0, ..HexConfig::default() };
 //!
 //! let v = &include_bytes!("../tests/data");
+//! # #[cfg(feature = "alloc")]
 //! assert_eq!(config_hex(&v, cfg), format!("{:?}", v.hex_conf(cfg)));
 //!
 //! println!("{:?}", v.hex_conf(cfg));

--- a/src/pretty_hex.rs
+++ b/src/pretty_hex.rs
@@ -1,8 +1,10 @@
+#[cfg(feature = "alloc")]
 use alloc::string::String;
 use core::{default::Default, fmt};
 
 /// Returns a one-line hexdump of `source` grouped in default format without header
 /// and ASCII column.
+#[cfg(feature = "alloc")]
 pub fn simple_hex<T: AsRef<[u8]>>(source: &T) -> String {
     let mut writer = String::new();
     hex_write(&mut writer, source, HexConfig::simple()).unwrap_or(());
@@ -20,6 +22,7 @@ where
 
 /// Return a multi-line hexdump in default format complete with addressing, hex digits,
 /// and ASCII representation.
+#[cfg(feature = "alloc")]
 pub fn pretty_hex<T: AsRef<[u8]>>(source: &T) -> String {
     let mut writer = String::new();
     hex_write(&mut writer, source, HexConfig::default()).unwrap_or(());
@@ -37,6 +40,7 @@ where
 }
 
 /// Return a hexdump of `source` in specified format.
+#[cfg(feature = "alloc")]
 pub fn config_hex<T: AsRef<[u8]>>(source: &T, cfg: HexConfig) -> String {
     let mut writer = String::new();
     hex_write(&mut writer, source, cfg).unwrap_or(());

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,12 +1,14 @@
 #![no_std]
-#![cfg_attr(feature = "alloc", feature(alloc))]
 
+#[cfg(feature = "alloc")]
 extern crate alloc;
 extern crate pretty_hex;
 
+#[cfg(feature = "alloc")]
 use alloc::{format, string::String, vec, vec::Vec};
 use pretty_hex::*;
 
+#[cfg(feature = "alloc")]
 #[test]
 fn test_simple() {
     let bytes: Vec<u8> = (0..16).collect();
@@ -29,6 +31,7 @@ fn test_simple() {
     assert!(simple_hex(&vec![]).is_empty());
 }
 
+#[cfg(feature = "alloc")]
 #[test]
 fn test_pretty() {
     let bytes: Vec<u8> = (0..256).map(|x| x as u8).collect();
@@ -44,6 +47,7 @@ fn test_pretty() {
     assert_eq!("Length: 0 (0x0) bytes\n", pretty_hex(&vec![]));
 }
 
+#[cfg(feature = "alloc")]
 #[test]
 fn test_config() {
     let cfg = HexConfig {
@@ -139,4 +143,21 @@ fn test_config() {
         format!("{}", v.hex_conf(cfg)),
         "00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f 10 11 12"
     );
+}
+
+// This test case checks that hex_write works even without the alloc crate.
+// Decorators to this function like simple_hex_write or PrettyHex::hex_dump()
+// will be tested when the alloc feature is selected because it feels quite
+// cumbersome to set up these tests without the comodity from `alloc`.
+#[test]
+fn test_hex_write_with_simple_config() {
+    let config = HexConfig::simple();
+    let bytes = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+    let expected = core::str::from_utf8(b"00 01 02 03  04 05 06 07  08 09 0a 0b  0c 0d 0e 0f").unwrap();
+    let mut buffer = heapless::Vec::<u8, heapless::consts::U50>::new();
+
+    hex_write(&mut buffer, &bytes, config).unwrap();
+
+    let have = core::str::from_utf8(&buffer).unwrap();
+    assert_eq!(expected, have);
 }


### PR DESCRIPTION
Thank you for this awesome crate Andrei! I'd really like the using the formatters from PrettyHex::hex_dump which feels pretty elegant for logging. :)

The previously used 'feature(alloc)' got rejected on stable Rust 1.46.0. By switching to 'cfg(feature = "alloc")' this crate builts on stable and with the Cargo configuration 'default-features = false' with a reduced interface even without an allocator.

I'm not firm with nightly Rust and don't now much about `#[feature(...)]`. Does https://github.com/sirhcel/pretty-hex/commit/1a5542ac468ce3e02b66acfed1fbf5d541db7537#diff-b4aea3e418ccdb71239b96952d9cddb6L2 enable the stuff depending on String for the whole library? To me it looks like using `alloc` is generally enabled by default. So I explicitly turned it on in my change. Please feel free to edit the commit or give me a sign and I will clean it up.