### PR TITLE
Address prefix optional offset and variable width support

### DIFF
--- a/src/pretty_hex.rs
+++ b/src/pretty_hex.rs
@@ -151,7 +151,11 @@ where
 
     let lines_len = lines.len();
 
-    let max_address = source.len() - cfg.width + cfg.display_offset;
+    let max_address = if source.len() <= cfg.width {
+        source.len() + cfg.display_offset
+    } else {
+        source.len() - cfg.width + cfg.display_offset
+    };
     let write_address = get_address_writer(max_address);
 
     for (i, row) in lines.enumerate() {

--- a/src/pretty_hex.rs
+++ b/src/pretty_hex.rs
@@ -62,6 +62,8 @@ pub struct HexConfig {
     pub chunk: usize,
     /// Maximum bytes to print.
     pub max_bytes: usize,
+    /// Offset added to displayed address prefix
+    pub display_offset: usize,
 }
 
 /// Default configuration with `title`, `ascii`, 16 source bytes `width` grouped to 4 separate
@@ -75,6 +77,7 @@ impl Default for HexConfig {
             group: 4,
             chunk: 1,
             max_bytes: usize::MAX,
+            display_offset: 0,
         }
     }
 }
@@ -136,7 +139,7 @@ where
     let lines_len = lines.len();
     for (i, row) in lines.enumerate() {
         if cfg.width > 0 {
-            write!(writer, "{:04x}:   ", i * cfg.width)?;
+            write!(writer, "{:04x}:   ", i * cfg.width + cfg.display_offset)?;
         }
         for (i, x) in row.as_ref().iter().enumerate() {
             write!(writer, "{}{:02x}", cfg.delimiter(i), x)?;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -57,6 +57,7 @@ fn test_config() {
         group: 0,
         chunk: 0,
         max_bytes: usize::MAX,
+        display_offset: 0
     };
     assert!(config_hex(&vec![], cfg).is_empty());
     assert_eq!("2425262728", config_hex(&"$%&'(", cfg));
@@ -95,6 +96,18 @@ fn test_config() {
          0010:   89d5 cf90 2367 4b48  dbb1 bc35 bfee"
     );
 
+    assert_eq!(
+        config_hex(&v,
+            HexConfig {
+                ascii: false,
+                display_offset: 0x200,
+                ..cfg
+            }
+        ),
+        "0200:   6b 4e 1a c3 af 03 d2 1e  7e 73 ba c8 bd 84 0f 83\n\
+         0210:   89 d5 cf 90 23 67 4b 48  db b1 bc 35 bf ee"
+    );
+
     let v: Vec<u8> = (0..21).collect();
     let want = r##"Length: 21 (0x15) bytes
 0000:   00 01 02 03  04 05 06 07  08 09 0a 0b  0c 0d 0e 0f   ................
@@ -111,6 +124,7 @@ fn test_config() {
                 group: 2,
                 chunk: 3,
                 max_bytes: usize::MAX,
+                display_offset: 0
             }),
         "0000:   000102 030405  060708 090a   ...........\n\
          000b:   0b0c                         .."
@@ -126,6 +140,7 @@ fn test_config() {
                 group: 3,
                 chunk: 3,
                 max_bytes: usize::MAX,
+                display_offset: 0
             }
         ),
         "0000:   000102 030405 060708  090a0b 0c0d0e 0f   ................\n\


### PR DESCRIPTION
Using the library I found the need to print address prefixes starting from a pre-determined offset instead of 0,
so I added `display_offset` field to `HexConfig` (defaults to 0). 

Before:
```
0000:   00 c3 50 01  ce ed 66 66   ..P...ff
0008:   cc 0d 00 0b  03 73 00 83   .....s..
```

With `display_offset` set to 0x0100:
```
0100:   00 c3 50 01  ce ed 66 66   ..P...ff
0108:   cc 0d 00 0b  03 73 00 83   .....s..
```

As a consequence, since now addresses can be greater than 0xff, I added support for automatically displaying addresses with larger width.

With `display_offset` set to 0x010000:
```
010000:   00 c3 50 01  ce ed 66 66   ..P...ff
010008:   cc 0d 00 0b  03 73 00 83   .....s..
```

With `display_offset` set to 0x10000000:
```
10000000:   00 c3 50 01  ce ed 66 66   ..P...ff
10000008:   cc 0d 00 0b  03 73 00 83   .....s..
```